### PR TITLE
Don't run `tarsnap --fsck` before launching backup

### DIFF
--- a/templates/backup.sh
+++ b/templates/backup.sh
@@ -15,8 +15,6 @@ timestamp=$(date -Isecond)
 # We run --fsck before backup, so in case of any inconsistencies (that might happen)
 # backups will still work
 
-/usr/local/bin/tarsnap --fsck --keyfile "{{ TARSNAP_KEY_REMOTE_LOCATION }}" \
---cachedir "{{ TARSNAP_CACHE }}" && \
 /usr/local/bin/tarsnap -c --keyfile "{{ TARSNAP_KEY_REMOTE_LOCATION }}" \
 --cachedir "{{ TARSNAP_CACHE }}"  -f "{{ TARSNAP_ARCHIVE_NAME }}-${timestamp}" \
 {{ TARSNAP_BACKUP_FOLDERS }} {% if TARSNAP_BACKUP_SNITCH %} && curl {{ TARSNAP_BACKUP_SNITCH }} {% endif %}


### PR DESCRIPTION
This change is a quick fix to a race condition caused by `tarsnap --fsck` taking more than an hour to run. It's a problem because the cronjob is scheduled hourly, and the post-backup script still runs when it fails.

CC @smarnach 
