### PR TITLE
Allow this role to be included multiple times.

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,6 +1,7 @@
+allow_duplicates: yes
 dependencies:
- # This depends on our fork of pmbauer.tarsnap (I hope changes will be accepted upstream)
- - name: pmbauer.tarsnap
-   tarsnap_tarsnapper_conf: null
-   tarsnap_cache: "{{ TARSNAP_CACHE }}"
-   tarsnap_keyfile: "{{ TARSNAP_KEY_REMOTE_LOCATION }}"
+  # This depends on our fork of pmbauer.tarsnap (I hope changes will be accepted upstream)
+  - name: pmbauer.tarsnap
+    tarsnap_tarsnapper_conf: null
+    tarsnap_cache: "{{ TARSNAP_CACHE }}"
+    tarsnap_keyfile: "{{ TARSNAP_KEY_REMOTE_LOCATION }}"


### PR DESCRIPTION
The role is a dependency of both common-server and backup-swift-container, with different settings in each case, so it should run twice.  See the [Ansible documentation](http://docs.ansible.com/ansible/playbooks_roles.html#role-dependencies) for details on the setting I added.