### PR TITLE
Prevent multiple simultaneous backups.

### DIFF
--- a/templates/backup.sh
+++ b/templates/backup.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+# Acquire backup lock using this script itself as the lockfile. If another
+# backup task is already running, then exit immediately.
+exec 200<$0
+flock -n 200 || { echo "Another backup task is already running."; exit 1; }
+
 # Logic is as follows:
 
 # 1. If pre-script fails exit immediately


### PR DESCRIPTION
Add lock to backup.sh to prevent multiple backup tasks from running at the same time.

**Testing instructions**:

1. Manually start a backup task via the backup.sh installed on the server.
2. Launch another backup task while the first one is still running.
3. The second command should fail with the message "Another backup task is already running."

**Reviewers**
- [ ] @kaizoku 