### PR TITLE
Write output of backup cron job to log file.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,3 +38,5 @@ TARSNAP_BACKUP_MINUTE: '10'
 
 TARSNAP_CACHE: "/var/cache/tarsnap"
 
+TARSNAP_BACKUP_LOG_FILE: /var/log/backup.log
+TARSNAP_BACKUP_LOGROTATE_CONFIG: /etc/logrotate.d/backup

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,7 +38,12 @@
 - name: Install backup in cron
   cron:
     name: "Backup for this server, archive: {{ TARSNAP_ARCHIVE_NAME }}"
-    job: "{{ TARSNAP_BACKUP_SCRIPT_LOCATION }} > /dev/null 2>&1"
+    job: "{{ TARSNAP_BACKUP_SCRIPT_LOCATION }} >> {{ TARSNAP_BACKUP_LOG_FILE }} 2>&1"
     hour: "{{ TARSNAP_BACKUP_HOUR }}"
     minute: "{{ TARSNAP_BACKUP_MINUTE }}"
     state: "{{ TARSNAP_CRONTAB_STATE }}"
+
+- name: Set up log rotation for backup logs
+  template:
+    src: logrotate
+    dest: "{{ TARSNAP_BACKUP_LOGROTATE_CONFIG }}"

--- a/templates/backup.sh
+++ b/templates/backup.sh
@@ -24,6 +24,6 @@ timestamp=$(date -Isecond)
 --cachedir "{{ TARSNAP_CACHE }}" && \
 /usr/local/bin/tarsnap -c --keyfile "{{ TARSNAP_KEY_REMOTE_LOCATION }}" \
 --cachedir "{{ TARSNAP_CACHE }}"  -f "{{ TARSNAP_ARCHIVE_NAME }}-${timestamp}" \
-{{ TARSNAP_BACKUP_FOLDERS }} {% if TARSNAP_BACKUP_SNITCH %} && curl {{ TARSNAP_BACKUP_SNITCH }} {% endif %}
+{{ TARSNAP_BACKUP_FOLDERS }} {% if TARSNAP_BACKUP_SNITCH %} && curl -sS {{ TARSNAP_BACKUP_SNITCH }} {% endif %}
 
 {% if TARSNAP_BACKUP_POST_SCRIPT %}{{ TARSNAP_BACKUP_POST_SCRIPT }}{% endif %}

--- a/templates/logrotate
+++ b/templates/logrotate
@@ -1,0 +1,9 @@
+{{ TARSNAP_BACKUP_LOG_FILE }} {
+        daily
+        rotate 14
+        compress
+        delaycompress
+        missingok
+        notifempty
+        create 644 root root
+}


### PR DESCRIPTION
The old version of the role sends the whole output of the backup script to `/dev/null`, which makes it hard to debug problems with the backup.  This change sends the output to a log file instead.

I've already deployed the change to {{haproxy-stage}}, so after the backup ran for the next time you should be able to see the log file there.